### PR TITLE
Potential fix for code scanning alert no. 10: Prototype-polluting assignment

### DIFF
--- a/src/lib/setValueByPath.ts
+++ b/src/lib/setValueByPath.ts
@@ -9,6 +9,10 @@ export function setValueByPath(obj: any, path: string, value: any): void {
     const nextPart = parts[i + 1];
     const isNextPartArrayIndex = /^\d+$/.test(nextPart);
 
+    if (part === '__proto__' || part === 'constructor' || part === 'prototype') {
+      throw new Error('Invalid path part: ' + part);
+    }
+
     if (!(part in current)) {
       current[part] = isNextPartArrayIndex ? [] : {};
     }
@@ -29,6 +33,9 @@ export function setValueByPath(obj: any, path: string, value: any): void {
   }
 
   const lastPart = parts[parts.length - 1];
+  if (lastPart === '__proto__' || lastPart === 'constructor' || lastPart === 'prototype') {
+    throw new Error('Invalid path part: ' + lastPart);
+  }
   if (/^\d+$/.test(lastPart)) {
     const index = parseInt(lastPart, 10);
     if (!Array.isArray(current)) {

--- a/tests/setValueByPath.spec.ts
+++ b/tests/setValueByPath.spec.ts
@@ -37,4 +37,16 @@ describe('setValueByPath', () => {
     setValueByPath(obj, '$.users[0].name', 'John');
     expect(obj).toEqual({ users: [{ name: 'John' }] });
   });
+
+  it('should raise error if path is invalid', () => {
+    const obj = {};
+    const invalidPatths = [
+      '__proto__',
+      'constructor',
+      'prototype',
+    ];
+    for (const path of invalidPatths) {
+      expect(() => setValueByPath(obj, `$.${path}`, 'John')).toThrowError();
+    }
+  });
 });


### PR DESCRIPTION
Potential fix for [https://github.com/versa-stack/v-craft/security/code-scanning/10](https://github.com/versa-stack/v-craft/security/code-scanning/10)

To fix the prototype pollution vulnerability, we need to ensure that the path parts do not include dangerous property names like `__proto__`, `constructor`, or `prototype`. We can achieve this by adding a check to filter out these property names before assigning values to the object.

- Add a check to filter out dangerous property names in the `setValueByPath` function.
- Specifically, modify the code to include a validation step that ensures none of the parts in the path are `__proto__`, `constructor`, or `prototype`.
- This change will be made in the `src/lib/setValueByPath.ts` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
