### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/versa-stack/v-craft/security/code-scanning/1](https://github.com/versa-stack/v-craft/security/code-scanning/1)

Added permissions to test workflow.