### PR TITLE
docs: relocate CSS injection script and improve documentation clarity

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -30,7 +30,6 @@
   - `assets/` - SCSS assets
 - `docs/` - VitePress documentation
 - `tests/` - Test files
-- `scripts/` - Build and utility scripts
 
 ## Common Commands
 
@@ -56,7 +55,7 @@ The build process involves:
 1. Building the library with Vite (`npm run build`)
 2. Copying the generated CSS to docs theme
 3. Building VitePress docs
-4. Running post-build CSS injection script (`scripts/inject-tailwind-css.js`)
+4. Running post-build CSS injection script (`docs/.vitepress/inject-tailwind-css.js`)
 
 **Important**: The post-build script is critical for ensuring Tailwind CSS is properly injected into the documentation HTML files.
 
@@ -136,7 +135,7 @@ Components can have multiple named slots. The editor supports this natively:
 
 ## Important Notes
 
-1. **CSS Injection**: The `scripts/inject-tailwind-css.js` script is essential for production docs builds. It ensures Tailwind CSS is properly linked in HTML files.
+1. **CSS Injection**: The `docs/.vitepress/inject-tailwind-css.js` script is specific to the VitePress documentation build process. It ensures Tailwind CSS is properly linked in the documentation HTML files. When using v-craft in your own application, iframe CSS injection is an application responsibility (via the `inheritStyles` prop or manual style injection).
 
 2. **TypeScript**: The project uses strict TypeScript. Ensure types are properly defined when making changes.
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -67,6 +67,11 @@ export default defineConfig({
     },
     build: {
       cssCodeSplit: true,
+      rollupOptions: {
+        input: {
+          frame: path.resolve(__dirname, "theme/frame.css"),
+        },
+      },
     },
   },
 });

--- a/docs/.vitepress/inject-tailwind-css.js
+++ b/docs/.vitepress/inject-tailwind-css.js
@@ -3,7 +3,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const distDir = path.resolve(__dirname, "../docs/.vitepress/dist");
+const distDir = path.resolve(__dirname, "dist");
 const base = process.env.PUBLIC_BASE || "/";
 
 function injectTailwindCSS() {
@@ -45,9 +45,12 @@ function injectTailwindCSS() {
         if (stat.isDirectory()) {
           walkDir(filePath);
         } else if (file.endsWith(".html")) {
-          let content = fs.readFileSync(filePath, "utf-8");
+          let content = fs.readFileSync(filePath, "utf8");
 
-          if (!content.includes(`${base}assets/${cssFile}`)) {
+          // Check for regular stylesheet link, not preload
+          const hasRegularStylesheetLink = content.includes(`<link rel="stylesheet" href="${base}assets/${cssFile}"`);
+          
+          if (!hasRegularStylesheetLink) {
             content = content.replace("</head>", `${cssLink}\n  </head>`);
             fs.writeFileSync(filePath, content);
             console.log(`✓ Injected CSS into ${path.relative(distDir, filePath)}`);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-raw": "vite build",
     "build": "rimraf dist && vite build",
     "docs:dev": "vitepress dev docs",
-    "docs:build": "npm run build && cp dist/v-craft.css docs/.vitepress/theme/ && vitepress build docs && node scripts/inject-tailwind-css.js",
+    "docs:build": "npm run build && cp dist/v-craft.css docs/.vitepress/theme/ && vitepress build docs && node docs/.vitepress/inject-tailwind-css.js",
     "docs:serve": "vitepress serve docs",
     "watch:build": "nodemon -e ts -e vue -x \"npm run build\"",
     "docs:preview": "vitepress preview docs",


### PR DESCRIPTION
- Move inject-tailwind-css.js from scripts/ to docs/.vitepress/
- Update script path references in package.json and agents.md
- Clarify CSS injection is VitePress-specific, not a v-craft library requirement
- Add rollupOptions for frame.css in VitePress config
- Improve injection detection to check for regular stylesheet links vs preload links
- Remove scripts/ directory from project structure documentation