### PR TITLE
feat: add runtime primitives for event-driven service bindings

### DIFF
--- a/src/components/CraftNodeEditor.vue
+++ b/src/components/CraftNodeEditor.vue
@@ -4,9 +4,10 @@
     v-if="visible && craftNode && resolvedNode"
     v-bind="{
       ...nodeProps,
+      ...runtimeProps,
       [`data-craft-uuid`]: craftNode.uuid,
     }"
-    v-on="eventHandlers"
+    v-on="finalEventHandlers"
     :is="componentToRender"
     :class="{
       'v-craft-node-selected': isSelected,
@@ -163,15 +164,40 @@ const { handleDragStart, handleDragOver, handleDrop, handleDragEnd } =
 const { eventHandlers } = useCraftNodeEvents(
   craftNode,
   editor?.eventsContext || {},
-  () =>
-    editor?.nodeMap
-      ? (Object.fromEntries(editor.nodeMap.entries()) as Record<
-          string,
-          CraftNode
-        >)
-      : null,
-  (uuid) => editor?.nodeMap[uuid] ?? null,
+  {
+    getNodes: () =>
+      editor?.nodeMap
+        ? (Object.fromEntries(editor.nodeMap.entries()) as Record<
+            string,
+            CraftNode
+          >)
+        : null,
+    getNode: (uuid) => editor?.nodeMap.get(uuid) ?? null,
+    nodeValues: editor?.nodeRuntimeProps,
+    setNodeProps: (uuid, patch) => editor?.setNodeRuntimeProps(uuid, patch),
+    state: editor?.pageState,
+  },
 );
+
+const runtimeProps = computed(() => editor?.nodeRuntimeProps[craftNode.value.uuid] || {});
+
+const captureNodeValue = (value: any) => {
+  editor?.setNodeRuntimeProps(craftNode.value.uuid, { value });
+};
+
+const finalEventHandlers = computed(() => {
+  const compose = (name: string, capture: (...args: any[]) => void) => (...args: any[]) => {
+    capture(...args);
+    (eventHandlers.value[name] as ((...a: any[]) => void) | undefined)?.(...args);
+  };
+
+  return {
+    ...eventHandlers.value,
+    input: compose("input", (e: Event) => captureNodeValue((e?.target as HTMLInputElement)?.value)),
+    change: compose("change", (e: Event) => captureNodeValue((e?.target as HTMLInputElement)?.value)),
+    "update:modelValue": compose("update:modelValue", (value: any) => captureNodeValue(value)),
+  };
+});
 
 const nodeName = computed(() => {
   const resolved = resolver?.value?.resolve(craftNode.value.componentName);

--- a/src/components/CraftNodeStatic.vue
+++ b/src/components/CraftNodeStatic.vue
@@ -7,8 +7,8 @@
       resolvedNode
     "
     :is="componentToRender"
-    v-bind="nodeProps"
-    v-on="eventHandlers"
+    v-bind="finalProps"
+    v-on="finalEventHandlers"
   >
     <template
       v-for="slotName in availableSlots"
@@ -23,6 +23,8 @@
           :nodeMap="nodeMap"
           :nodeDataMap="nodeDataMap"
           :eventsContext="eventsContext"
+          :nodeRuntimeProps="nodeRuntimeProps"
+          :pageState="pageState"
           :context="buildChildContext(slotName, slotProps)"
         />
       </template>
@@ -34,6 +36,8 @@
           :nodeMap="nodeMap"
           :nodeDataMap="nodeDataMap"
           :eventsContext="eventsContext"
+          :nodeRuntimeProps="nodeRuntimeProps"
+          :pageState="pageState"
           :context="buildChildContext(slotName, slotProps, item.dataItem)"
         />
       </template>
@@ -62,6 +66,8 @@ const props = defineProps<{
   nodeMap: Map<string, CraftNode>;
   nodeDataMap?: Record<string, CraftNodeDatasource>;
   eventsContext?: Record<string, any>;
+  nodeRuntimeProps?: Record<string, Record<string, any>>;
+  pageState?: Record<string, any>;
   context?: CraftNodePropsContext;
 }>();
 
@@ -134,12 +140,41 @@ const computedChildren = (children: CraftNode[], slotName: string) => {
   return computeDataNodes(data.value, children);
 };
 
+const setNodeRuntimeProps = (uuid: string, patch: Record<string, any>) => {
+  if (!props.nodeRuntimeProps) return;
+  props.nodeRuntimeProps[uuid] = { ...(props.nodeRuntimeProps[uuid] || {}), ...patch };
+};
+
 const { eventHandlers } = useCraftNodeEvents(
   craftNode,
   props.eventsContext || {},
-  () => Object.fromEntries(nodeMap.value.entries()),
-  (uuid) => nodeMap.value[uuid] ?? null,
+  {
+    getNodes: () => Object.fromEntries(nodeMap.value.entries()),
+    getNode: (uuid) => nodeMap.value.get(uuid) ?? null,
+    nodeValues: props.nodeRuntimeProps,
+    setNodeProps: setNodeRuntimeProps,
+    state: props.pageState,
+  },
 );
+
+const finalProps = computed(() => ({
+  ...nodeProps.value,
+  ...(props.nodeRuntimeProps?.[craftNode.value.uuid] || {}),
+}));
+
+const finalEventHandlers = computed(() => {
+  const compose = (name: string, capture: (...args: any[]) => void) => (...args: any[]) => {
+    capture(...args);
+    (eventHandlers.value[name] as ((...a: any[]) => void) | undefined)?.(...args);
+  };
+
+  return {
+    ...eventHandlers.value,
+    input: compose("input", (e: Event) => setNodeRuntimeProps(craftNode.value.uuid, { value: (e?.target as HTMLInputElement)?.value })),
+    change: compose("change", (e: Event) => setNodeRuntimeProps(craftNode.value.uuid, { value: (e?.target as HTMLInputElement)?.value })),
+    "update:modelValue": compose("update:modelValue", (value: any) => setNodeRuntimeProps(craftNode.value.uuid, { value })),
+  };
+});
 
 type ComputedDataNode = {
   key: string;

--- a/src/components/CraftNodeViewer.vue
+++ b/src/components/CraftNodeViewer.vue
@@ -3,8 +3,8 @@
     ref="nodeRef"
     v-if="visible && resolver && resolvedNode"
     :is="componentToRender"
-    v-bind="nodeProps"
-    v-on="eventHandlers"
+    v-bind="{ ...nodeProps, ...runtimeProps }"
+    v-on="finalEventHandlers"
   >
     <template
       v-for="slotName in availableSlots"
@@ -134,15 +134,40 @@ const nodeRef = ref<HTMLElement | null>(null);
 const { eventHandlers } = useCraftNodeEvents(
   craftNode,
   props.eventsContext || editor?.eventsContext || {},
-  () =>
-    editor?.nodeMap
-      ? (Object.fromEntries(editor.nodeMap.entries()) as Record<
-          string,
-          CraftNode
-        >)
-      : null,
-  (uuid) => editor?.nodeMap[uuid] ?? null,
+  {
+    getNodes: () =>
+      editor?.nodeMap
+        ? (Object.fromEntries(editor.nodeMap.entries()) as Record<
+            string,
+            CraftNode
+          >)
+        : null,
+    getNode: (uuid) => editor?.nodeMap.get(uuid) ?? null,
+    nodeValues: editor?.nodeRuntimeProps,
+    setNodeProps: (uuid, patch) => editor?.setNodeRuntimeProps(uuid, patch),
+    state: editor?.pageState,
+  },
 );
+
+const runtimeProps = computed(() => editor?.nodeRuntimeProps[craftNode.value.uuid] || {});
+
+const captureNodeValue = (value: any) => {
+  editor?.setNodeRuntimeProps(craftNode.value.uuid, { value });
+};
+
+const finalEventHandlers = computed(() => {
+  const compose = (name: string, capture: (...args: any[]) => void) => (...args: any[]) => {
+    capture(...args);
+    (eventHandlers.value[name] as ((...a: any[]) => void) | undefined)?.(...args);
+  };
+
+  return {
+    ...eventHandlers.value,
+    input: compose("input", (e: Event) => captureNodeValue((e?.target as HTMLInputElement)?.value)),
+    change: compose("change", (e: Event) => captureNodeValue((e?.target as HTMLInputElement)?.value)),
+    "update:modelValue": compose("update:modelValue", (value: any) => captureNodeValue(value)),
+  };
+});
 
 onMounted(() => {
   if (nodeRef.value && craftNode.value && editor) {

--- a/src/components/CraftStaticRenderer.vue
+++ b/src/components/CraftStaticRenderer.vue
@@ -6,6 +6,8 @@
     :nodeMap="nodeMap"
     :nodeDataMap="nodeDataMap"
     :eventsContext="eventsContext"
+    :nodeRuntimeProps="nodeRuntimeProps"
+    :pageState="pageState"
   />
 </template>
 
@@ -14,7 +16,7 @@
   setup
   generic="T extends FormKitSchemaDefinition = FormKitSchemaDefinition"
 >
-import { computed, provide, readonly } from "vue";
+import { computed, provide, reactive, readonly } from "vue";
 import { CraftNode, CraftNodeDatasource } from "../lib/craftNode";
 import CraftNodeResolver, {
   CraftNodeResolverMap,
@@ -57,4 +59,9 @@ const resolver = computed(
 provide("resolver", resolver);
 provide("nodeDataMap", props.nodeDataMap || {});
 provide("eventsContext", props.eventsContext || {});
+
+/** Live runtime props written by event handlers or captured from value-bearing nodes, by uuid. */
+const nodeRuntimeProps = reactive<Record<string, Record<string, any>>>({});
+/** Page-scoped bag shared across event handlers, e.g. a pending flag. */
+const pageState = reactive<Record<string, any>>({});
 </script>

--- a/src/components/composable/useCraftNodeEvents.ts
+++ b/src/components/composable/useCraftNodeEvents.ts
@@ -3,11 +3,22 @@ import { CraftNode } from "../../lib/craftNode";
 import { computed } from "vue";
 import { EditorStoreInstanceType } from "../../store/editor";
 
+/** Extra lookups/channels merged into `ctx` for compiled event code. */
+export interface CraftNodeEventsRuntime {
+  getNodes?: () => Record<string, CraftNode> | null;
+  getNode?: (uuid: string) => CraftNode | null;
+  /** Live runtime values captured from value-bearing nodes (e.g. what a user typed), keyed by uuid. */
+  nodeValues?: Record<string, Record<string, any>>;
+  /** Patch another node's rendered props at runtime, by uuid. */
+  setNodeProps?: (uuid: string, patch: Record<string, any>) => void;
+  /** Page-scoped bag shared across event handlers, e.g. a pending flag. */
+  state?: Record<string, any>;
+}
+
 export const useCraftNodeEvents = (
   craftNode: Ref<CraftNode>,
   ctx: Record<string, any>,
-  getNodes?: () => Record<string, CraftNode>|null,
-  getNode?: (uuid: string) => CraftNode|null,
+  runtime: CraftNodeEventsRuntime = {},
 ) => {
   const eventHandlersMap = new Map();
 
@@ -33,7 +44,7 @@ export const useCraftNodeEvents = (
             eventCode
           );
           eventHandler(
-            { ...ctx, getNodes, getNode },
+            { ...ctx, ...runtime },
             craftNode.value.uuid,
             ...args
           );

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -26,6 +26,10 @@ export interface EditorState {
   eventsContext: Record<string, any>;
   nodeDataMap: Record<string, CraftNodeDatasource | null>;
   draggingDisabled: boolean;
+  /** Live runtime props written by event handlers or captured from value-bearing nodes, by uuid. */
+  nodeRuntimeProps: Record<string, Record<string, any>>;
+  /** Page-scoped bag shared across event handlers, e.g. a pending flag. */
+  pageState: Record<string, any>;
 }
 
 export const useEditor = defineStore("editor", {
@@ -40,6 +44,8 @@ export const useEditor = defineStore("editor", {
     eventsContext: {},
     nodeDataMap: {},
     draggingDisabled: false,
+    nodeRuntimeProps: {},
+    pageState: {},
   }),
 
   actions: {
@@ -399,6 +405,10 @@ export const useEditor = defineStore("editor", {
 
     setEventsContext(context: Record<string, any>) {
       this.eventsContext = context;
+    },
+
+    setNodeRuntimeProps(uuid: string, patch: Record<string, any>) {
+      this.nodeRuntimeProps[uuid] = { ...(this.nodeRuntimeProps[uuid] || {}), ...patch };
     },
   },
 

--- a/tests/components/CraftNodeEditor.spec.ts
+++ b/tests/components/CraftNodeEditor.spec.ts
@@ -691,4 +691,95 @@ describe("CraftNodeEditor", () => {
     expect(dropTextElement.text()).toContain("Drop a component here");
     expect(dropTextElement.text()).toContain("default");
   });
+
+  describe("runtime event ctx via the editor store (nodeValues, setNodeProps, state, getNode)", () => {
+    const mountNode = (
+      craftNode: CraftNode,
+      resolverMap: CraftNodeResolverMap<any>,
+    ) =>
+      mount(CraftNodeEditor, {
+        props: { craftNode },
+        global: {
+          components: { CraftNodeViewer, CraftComponentSimpleText },
+          provide: { resolver: ref(new CraftNodeResolver(resolverMap)) },
+        },
+      });
+
+    it("captures a native input's typed value and exposes it to another node's click handler via ctx.nodeValues, resolving the target through ctx.getNode", async () => {
+      const editor = useEditor();
+      editor.enable();
+
+      const inputNode = { uuid: uuidv4(), componentName: "input", props: {}, slots: {} };
+      const outputNode = createSimpleText("before", "span");
+      const triggerNode = {
+        ...createSimpleText("trigger", "button"),
+        events: {
+          click: `if (ctx.getNode("${outputNode.uuid}") && Object.keys(ctx.getNodes() || {}).length > 0) ctx.setNodeProps("${outputNode.uuid}", { content: ctx.nodeValues["${inputNode.uuid}"]?.value ?? "" })`,
+        },
+      };
+
+      editor.setNodes([inputNode, outputNode, triggerNode]);
+
+      const resolverMap: CraftNodeResolverMap<any> = {
+        ...defaultResolvers,
+        input: { componentName: "input" },
+      };
+
+      const inputWrapper = mountNode(
+        editor.nodeMap.get(inputNode.uuid)!,
+        resolverMap,
+      );
+      const outputWrapper = mountNode(
+        editor.nodeMap.get(outputNode.uuid)!,
+        resolverMap,
+      );
+      const triggerWrapper = mountNode(
+        editor.nodeMap.get(triggerNode.uuid)!,
+        resolverMap,
+      );
+
+      await inputWrapper.find("input").setValue("typed value");
+      await triggerWrapper.trigger("click");
+      await nextTick();
+
+      expect(outputWrapper.text()).toBe("typed value");
+    });
+
+    it("shares ctx.state across separately mounted nodes", async () => {
+      const editor = useEditor();
+      editor.enable();
+
+      const counterNode = createSimpleText("0", "span");
+      const makeIncrementNode = () => ({
+        ...createSimpleText("click", "button"),
+        events: {
+          click: `ctx.state.count = (ctx.state.count || 0) + 1; ctx.setNodeProps("${counterNode.uuid}", { content: String(ctx.state.count) })`,
+        },
+      });
+      const firstNode = makeIncrementNode();
+      const secondNode = makeIncrementNode();
+
+      editor.setNodes([counterNode, firstNode, secondNode]);
+
+      const resolverMap: CraftNodeResolverMap<any> = { ...defaultResolvers };
+      const counterWrapper = mountNode(
+        editor.nodeMap.get(counterNode.uuid)!,
+        resolverMap,
+      );
+      const firstWrapper = mountNode(
+        editor.nodeMap.get(firstNode.uuid)!,
+        resolverMap,
+      );
+      const secondWrapper = mountNode(
+        editor.nodeMap.get(secondNode.uuid)!,
+        resolverMap,
+      );
+
+      await firstWrapper.trigger("click");
+      await secondWrapper.trigger("click");
+      await nextTick();
+
+      expect(counterWrapper.text()).toBe("2");
+    });
+  });
 });

--- a/tests/components/CraftNodeViewer.spec.ts
+++ b/tests/components/CraftNodeViewer.spec.ts
@@ -369,4 +369,93 @@ describe("CraftNodeViewer", () => {
     expect(wrapper.find(".async-parent").exists()).toBe(true);
     expect(wrapper.find(".async-leaf").exists()).toBe(true);
   });
+
+  describe("runtime event ctx via the editor store (nodeValues, setNodeProps, state, getNode)", () => {
+    const mountNode = (
+      craftNode: CraftNode,
+      resolverMap: CraftNodeResolverMap<any>,
+    ) =>
+      mount(CraftNodeViewer, {
+        props: { craftNode },
+        global: {
+          components: { CraftNodeViewer, CraftComponentSimpleText },
+          provide: { resolver: ref(new CraftNodeResolver(resolverMap)) },
+        },
+      });
+
+    it("captures a native input's typed value and exposes it to another node's click handler via ctx.nodeValues, resolving the target through ctx.getNode", async () => {
+      const editor = useEditor();
+
+      const inputNode = { uuid: uuidv4(), componentName: "input", props: {}, slots: {} };
+      const outputNode = createSimpleText("before", "span");
+      const triggerNode = {
+        ...createSimpleText("trigger", "button"),
+        events: {
+          click: `if (ctx.getNode("${outputNode.uuid}") && Object.keys(ctx.getNodes() || {}).length > 0) ctx.setNodeProps("${outputNode.uuid}", { content: ctx.nodeValues["${inputNode.uuid}"]?.value ?? "" })`,
+        },
+      };
+
+      editor.setNodes([inputNode, outputNode, triggerNode]);
+
+      const resolverMap: CraftNodeResolverMap<any> = {
+        ...defaultResolvers,
+        input: { componentName: "input" },
+      };
+
+      const inputWrapper = mountNode(
+        editor.nodeMap.get(inputNode.uuid)!,
+        resolverMap,
+      );
+      const outputWrapper = mountNode(
+        editor.nodeMap.get(outputNode.uuid)!,
+        resolverMap,
+      );
+      const triggerWrapper = mountNode(
+        editor.nodeMap.get(triggerNode.uuid)!,
+        resolverMap,
+      );
+
+      await inputWrapper.find("input").setValue("typed value");
+      await triggerWrapper.trigger("click");
+      await nextTick();
+
+      expect(outputWrapper.text()).toBe("typed value");
+    });
+
+    it("shares ctx.state across separately mounted nodes", async () => {
+      const editor = useEditor();
+
+      const counterNode = createSimpleText("0", "span");
+      const makeIncrementNode = () => ({
+        ...createSimpleText("click", "button"),
+        events: {
+          click: `ctx.state.count = (ctx.state.count || 0) + 1; ctx.setNodeProps("${counterNode.uuid}", { content: String(ctx.state.count) })`,
+        },
+      });
+      const firstNode = makeIncrementNode();
+      const secondNode = makeIncrementNode();
+
+      editor.setNodes([counterNode, firstNode, secondNode]);
+
+      const resolverMap: CraftNodeResolverMap<any> = { ...defaultResolvers };
+      const counterWrapper = mountNode(
+        editor.nodeMap.get(counterNode.uuid)!,
+        resolverMap,
+      );
+      const firstWrapper = mountNode(
+        editor.nodeMap.get(firstNode.uuid)!,
+        resolverMap,
+      );
+      const secondWrapper = mountNode(
+        editor.nodeMap.get(secondNode.uuid)!,
+        resolverMap,
+      );
+
+      await firstWrapper.trigger("click");
+      await secondWrapper.trigger("click");
+      await nextTick();
+
+      expect(counterWrapper.text()).toBe("2");
+    });
+  });
 });

--- a/tests/components/CraftStaticRenderer.spec.ts
+++ b/tests/components/CraftStaticRenderer.spec.ts
@@ -626,4 +626,157 @@ describe("CraftStaticRenderer", () => {
     expect(wrapper.vm).toBeTruthy();
     expect(wrapper.find(".test-component").exists()).toBe(true);
   });
+
+  describe("runtime event ctx (nodeValues, setNodeProps, state, getNode)", () => {
+    const runtimeResolverMap: CraftNodeResolverMap<any> = {
+      ...resolverMap,
+      input: { componentName: "input" },
+    };
+
+    const createRuntimeWrapper = (nodes: CraftNode[]) =>
+      mount(CraftStaticRenderer, {
+        props: { nodes, resolverMap: runtimeResolverMap },
+        global: {
+          components: {
+            TestComponent,
+            CraftStaticRenderer,
+            CraftNodeStatic,
+            CraftComponentSimpleText,
+            CraftCanvas,
+          },
+        },
+      });
+
+    it("captures a native input's typed value and exposes it to another node's click handler via ctx.nodeValues", async () => {
+      const inputUuid = uuidv4();
+      const outputUuid = uuidv4();
+      const triggerUuid = uuidv4();
+
+      const nodes: CraftNode[] = [
+        { uuid: inputUuid, componentName: "input", props: {}, slots: {} },
+        {
+          uuid: outputUuid,
+          componentName: "TestComponent",
+          props: { text: "before" },
+          slots: {},
+        },
+        {
+          uuid: triggerUuid,
+          componentName: "TestComponent",
+          props: { text: "trigger" },
+          slots: {},
+          events: {
+            click: `ctx.setNodeProps("${outputUuid}", { text: ctx.nodeValues["${inputUuid}"]?.value ?? "" })`,
+          },
+        },
+      ];
+
+      const wrapper = createRuntimeWrapper(nodes);
+      await wrapper.find("input").setValue("typed value");
+      await wrapper.findAll(".test-component")[1].trigger("click");
+      await nextTick();
+
+      expect(wrapper.findAll(".test-component")[0].text()).toBe("typed value");
+    });
+
+    it("getNode resolves a node by uuid (regression: Map lookup via bracket access always returned undefined)", async () => {
+      const targetUuid = uuidv4();
+      const triggerUuid = uuidv4();
+
+      const nodes: CraftNode[] = [
+        {
+          uuid: targetUuid,
+          componentName: "TestComponent",
+          props: { text: "before" },
+          slots: {},
+        },
+        {
+          uuid: triggerUuid,
+          componentName: "TestComponent",
+          props: { text: "trigger" },
+          slots: {},
+          events: {
+            click: `ctx.setNodeProps("${targetUuid}", { text: ctx.getNode("${targetUuid}") ? "found" : "missing" })`,
+          },
+        },
+      ];
+
+      const wrapper = createRuntimeWrapper(nodes);
+      await wrapper.findAll(".test-component")[1].trigger("click");
+      await nextTick();
+
+      expect(wrapper.findAll(".test-component")[0].text()).toBe("found");
+    });
+
+    it("shares ctx.state across event handlers on different nodes", async () => {
+      const counterUuid = uuidv4();
+      const firstUuid = uuidv4();
+      const secondUuid = uuidv4();
+
+      const nodes: CraftNode[] = [
+        {
+          uuid: counterUuid,
+          componentName: "TestComponent",
+          props: { text: "0" },
+          slots: {},
+        },
+        {
+          uuid: firstUuid,
+          componentName: "TestComponent",
+          props: { text: "first" },
+          slots: {},
+          events: {
+            click: `ctx.state.count = (ctx.state.count || 0) + 1; ctx.setNodeProps("${counterUuid}", { text: String(ctx.state.count) })`,
+          },
+        },
+        {
+          uuid: secondUuid,
+          componentName: "TestComponent",
+          props: { text: "second" },
+          slots: {},
+          events: {
+            click: `ctx.state.count = (ctx.state.count || 0) + 1; ctx.setNodeProps("${counterUuid}", { text: String(ctx.state.count) })`,
+          },
+        },
+      ];
+
+      const wrapper = createRuntimeWrapper(nodes);
+      await wrapper.findAll(".test-component")[1].trigger("click");
+      await wrapper.findAll(".test-component")[2].trigger("click");
+      await nextTick();
+
+      expect(wrapper.findAll(".test-component")[0].text()).toBe("2");
+    });
+
+    it("gives nodeRuntimeProps precedence over the node's own authored props", async () => {
+      const targetUuid = uuidv4();
+      const triggerUuid = uuidv4();
+
+      const nodes: CraftNode[] = [
+        {
+          uuid: targetUuid,
+          componentName: "TestComponent",
+          props: { text: "authored" },
+          slots: {},
+        },
+        {
+          uuid: triggerUuid,
+          componentName: "TestComponent",
+          props: { text: "trigger" },
+          slots: {},
+          events: {
+            click: `ctx.setNodeProps("${targetUuid}", { text: "overridden" })`,
+          },
+        },
+      ];
+
+      const wrapper = createRuntimeWrapper(nodes);
+      expect(wrapper.findAll(".test-component")[0].text()).toBe("authored");
+
+      await wrapper.findAll(".test-component")[1].trigger("click");
+      await nextTick();
+
+      expect(wrapper.findAll(".test-component")[0].text()).toBe("overridden");
+    });
+  });
 });

--- a/tests/store/editor.spec.ts
+++ b/tests/store/editor.spec.ts
@@ -29,6 +29,8 @@ describe("useEditor", () => {
     expect(store.draggedNode).toBeNull();
     expect(store.enabled).toBe(false);
     expect(store.nodeRefsRecord).toEqual({});
+    expect(store.nodeRuntimeProps).toEqual({});
+    expect(store.pageState).toEqual({});
   });
 
   it("should set and clear nodes", () => {
@@ -319,5 +321,38 @@ describe("useEditor", () => {
     expect(updatedNode?.slots).toHaveProperty("body");
     expect(updatedNode?.slots.header).toEqual([]);
     expect(updatedNode?.slots.body).toEqual([]);
+  });
+
+  describe("setNodeRuntimeProps", () => {
+    it("creates a runtime props entry for a uuid with no prior entry", () => {
+      const store = useEditor();
+      store.setNodeRuntimeProps("node-1", { value: "typed" });
+      expect(store.nodeRuntimeProps["node-1"]).toEqual({ value: "typed" });
+    });
+
+    it("merges into an existing entry instead of replacing it", () => {
+      const store = useEditor();
+      store.setNodeRuntimeProps("node-1", { value: "typed" });
+      store.setNodeRuntimeProps("node-1", { disabled: true });
+      expect(store.nodeRuntimeProps["node-1"]).toEqual({
+        value: "typed",
+        disabled: true,
+      });
+    });
+
+    it("overwrites only the keys provided in the patch", () => {
+      const store = useEditor();
+      store.setNodeRuntimeProps("node-1", { value: "first" });
+      store.setNodeRuntimeProps("node-1", { value: "second" });
+      expect(store.nodeRuntimeProps["node-1"]).toEqual({ value: "second" });
+    });
+
+    it("keeps separate uuids independent", () => {
+      const store = useEditor();
+      store.setNodeRuntimeProps("node-1", { value: "a" });
+      store.setNodeRuntimeProps("node-2", { value: "b" });
+      expect(store.nodeRuntimeProps["node-1"]).toEqual({ value: "a" });
+      expect(store.nodeRuntimeProps["node-2"]).toEqual({ value: "b" });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds a reactive `nodeRuntimeProps` registry (read/write another node's live value by uuid) and a page-scoped `pageState` bag, threaded through `CraftStaticRenderer`/`CraftNodeStatic`/`CraftNodeEditor`/`CraftNodeViewer`
- Generic `input`/`change`/`update:modelValue` capture so any rendered node's live value is readable without per-blueprint wiring
- Fixes `getNode` always returning `null` in the static/editor/viewer renderers (`Map` accessed with `[uuid]` instead of `.get(uuid)`)

This is the v-craft-side half of [nuxt-pagekit#23](https://github.com/versa-stack/nuxt-pagekit/issues/23) ("Integrate events with services") — the companion PR in nuxt-pagekit adds the `EventBinding` authoring UI and service-invoke plumbing that consumes these primitives.

## Test plan
- [x] Full existing test suite passes (`vitest run`, 163/163)
- [x] Verified live in the companion nuxt-pagekit branch: a button's click event reads another node's live typed value, invokes a service, and writes the result back onto a third node's props

🤖 Generated with [Claude Code](https://claude.com/claude-code)