### PR TITLE
feat: add onResolvePropertyValue hook for slotsPropsPropsMap resolution

### DIFF
--- a/src/components/CraftEditorPanelNodeSlotPropsSettings.vue
+++ b/src/components/CraftEditorPanelNodeSlotPropsSettings.vue
@@ -20,7 +20,8 @@
       <legend class="formkit-legend">Props Mapping</legend>
       <p class="formkit-help">
         Map fields from an ancestor slot's context into this component's own
-        props using JSONPath (e.g. <code>$.item.name</code>).
+        props using JSONPath (e.g. <code>$.item.name</code>), or paste a JSON
+        mapping object if the app supports richer transforms.
       </p>
 
       <p v-if="!mappingGroups.length" class="formkit-help">
@@ -66,9 +67,9 @@
             "
           />
           <FormKit
-            type="text"
-            label="JSONPath"
-            placeholder="$.item.name"
+            type="textarea"
+            label="JSONPath (or JSON mapping object)"
+            placeholder="$.item.name  (or paste a JSON transform object)"
             :value="field.fromPath"
             @input="
               (value) =>
@@ -130,9 +131,23 @@ const props = defineProps<{
 const emit = defineEmits<{
   (
     e: "update:slotsPropsPropsMap",
-    value: Record<string, Record<string, string>>,
+    value: Record<string, Record<string, unknown>>,
   ): void;
 }>();
+
+/** `fromPath` doubles as a JSON escape hatch: `{...}` parses as a mapping object, anything else is a literal JSONPath string. */
+const parseFromPath = (value: string): unknown => {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{")) return trimmed;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return trimmed;
+  }
+};
+
+const stringifyMapping = (mapping: unknown): string =>
+  typeof mapping === "string" ? mapping : JSON.stringify(mapping);
 
 const craftNode = toRef(props, "craftNode");
 const { buckets } = useAncestorContextBuckets(craftNode);
@@ -170,10 +185,10 @@ const syncFromNode = () => {
     ([bucket, fields]) => ({
       id: uuidv4(),
       bucket,
-      fields: Object.entries(fields).map(([targetProp, fromPath]) => ({
+      fields: Object.entries(fields).map(([targetProp, mapping]) => ({
         id: uuidv4(),
         targetProp,
-        fromPath,
+        fromPath: stringifyMapping(mapping),
       })),
     }),
   );
@@ -182,13 +197,13 @@ const syncFromNode = () => {
 watch(() => craftNode.value?.uuid, syncFromNode, { immediate: true });
 
 const emitMappingGroups = () => {
-  const result: Record<string, Record<string, string>> = {};
+  const result: Record<string, Record<string, unknown>> = {};
   mappingGroups.value.forEach((group) => {
     if (!group.bucket.trim()) return;
-    const fields: Record<string, string> = {};
+    const fields: Record<string, unknown> = {};
     group.fields.forEach((field) => {
       if (field.targetProp.trim() && field.fromPath.trim()) {
-        fields[field.targetProp.trim()] = field.fromPath.trim();
+        fields[field.targetProp.trim()] = parseFromPath(field.fromPath);
       }
     });
     if (Object.keys(fields).length) {

--- a/src/components/CraftEditorPanelSettings.vue
+++ b/src/components/CraftEditorPanelSettings.vue
@@ -131,7 +131,7 @@ const handleEventsUpdate = (newEvents: Record<string, any>) => {
 };
 
 const handleSlotsPropsPropsMapUpdate = (
-  slotsPropsPropsMap: Record<string, Record<string, string>>,
+  slotsPropsPropsMap: Record<string, Record<string, unknown>>,
 ) => {
   if (selectedNode.value) {
     editor.updateNodeSlotsPropsPropsMap(

--- a/src/components/composable/useResolveCraftNode.ts
+++ b/src/components/composable/useResolveCraftNode.ts
@@ -61,7 +61,11 @@ export const useResolveCraftNode = <T extends FormKitSchemaDefinition = FormKitS
     resolveComponent(resolver?.value, craftNode.value)
   );
 
-  const { props: contextProps } = useResolveCraftNodeProps(craftNode, context);
+  const { props: contextProps } = useResolveCraftNodeProps(
+    craftNode,
+    context,
+    () => resolver?.value,
+  );
 
   const props = computed(() => ({
     ...defaultProps.value,

--- a/src/components/composable/useResolveCraftNodeProps.ts
+++ b/src/components/composable/useResolveCraftNodeProps.ts
@@ -1,6 +1,7 @@
 import { JSONPath } from "jsonpath-plus";
 import { computed, ComputedRef, MaybeRefOrGetter, toValue } from "vue";
 import { CraftNode } from "../../lib/craftNode";
+import type CraftNodeResolver from "../../lib/CraftNodeResolver";
 import { setValueByPath } from "../../lib/setValueByPath";
 
 /**
@@ -9,9 +10,17 @@ import { setValueByPath } from "../../lib/setValueByPath";
  */
 export type CraftNodePropsContext = Record<string, Record<string, any>>;
 
+/** Default, resolver-less behavior: bare JSONPath lookup, no formatting. */
+const defaultResolveJSONPath = (mapping: unknown, contextData: any): unknown => {
+  if (typeof mapping !== "string") return undefined;
+  const matches = JSONPath({ path: mapping, json: contextData, resultType: "value" });
+  return matches.length ? matches[0] : undefined;
+};
+
 const resolveContextProps = (
   slotsPropsPropsMap: CraftNode["slotsPropsPropsMap"],
   context: CraftNodePropsContext,
+  resolver?: CraftNodeResolver<any>,
 ) => {
   const props: Record<string, any> = {};
   if (!slotsPropsPropsMap) return props;
@@ -20,14 +29,12 @@ const resolveContextProps = (
     const contextData = context[contextKey];
     if (contextData === undefined) return;
 
-    Object.entries(fieldMap).forEach(([toPath, fromPath]) => {
-      const matches = JSONPath({
-        path: fromPath,
-        json: contextData,
-        resultType: "value",
-      });
-      if (!matches.length) return;
-      setValueByPath(props, toPath, matches[0]);
+    Object.entries(fieldMap).forEach(([toPath, mapping]) => {
+      const value = resolver
+        ? resolver.resolvePropertyValue(mapping, contextData)
+        : defaultResolveJSONPath(mapping, contextData);
+      if (value === undefined) return;
+      setValueByPath(props, toPath, value);
     });
   });
 
@@ -37,9 +44,14 @@ const resolveContextProps = (
 export const useResolveCraftNodeProps = (
   node: MaybeRefOrGetter<CraftNode>,
   context: MaybeRefOrGetter<CraftNodePropsContext> = {},
+  resolver?: MaybeRefOrGetter<CraftNodeResolver<any> | undefined>,
 ): { props: ComputedRef<Record<string, any>> } => {
   const props = computed(() =>
-    resolveContextProps(toValue(node)?.slotsPropsPropsMap, toValue(context) || {}),
+    resolveContextProps(
+      toValue(node)?.slotsPropsPropsMap,
+      toValue(context) || {},
+      toValue(resolver),
+    ),
   );
 
   return {

--- a/src/lib/CraftNodeResolver.ts
+++ b/src/lib/CraftNodeResolver.ts
@@ -1,4 +1,5 @@
 import { type FormKitSchemaDefinition } from "@formkit/core";
+import { JSONPath } from "jsonpath-plus";
 import { markRaw, type Component } from "vue";
 import { CraftNode, craftNodeIsCanvas, CraftNodeRules } from "./craftNode";
 
@@ -25,11 +26,25 @@ export type ResolveComponentHook = (
   defaultResolver: (name: string) => Component | undefined,
 ) => Component | undefined;
 
+/**
+ * Lets a consuming app interpret a `slotsPropsPropsMap` mapping value however
+ * it likes (e.g. a formatter/transform pipeline) instead of the plain
+ * JSONPath default. `defaultResolve` runs a JSONPath against `contextData` —
+ * call it directly for the bare-string case, or as a source-value primitive
+ * within a richer mapping shape.
+ */
+export type ResolvePropertyValueHook = (
+  mapping: unknown,
+  contextData: any,
+  defaultResolve: (path: string) => unknown,
+) => unknown;
+
 export class CraftNodeResolver<
   T extends FormKitSchemaDefinition = FormKitSchemaDefinition,
 > {
   resolverMap: CraftNodeResolverMap<T> = {};
   private resolveComponentHook?: ResolveComponentHook;
+  private resolvePropertyValueHook?: ResolvePropertyValueHook;
 
   constructor(resolverMap: Record<string, CraftNodeComponentMap<T>> = {}) {
     this.setResolverMap(resolverMap);
@@ -45,6 +60,23 @@ export class CraftNodeResolver<
 
   onResolveComponent(hook: ResolveComponentHook): void {
     this.resolveComponentHook = hook;
+  }
+
+  onResolvePropertyValue(hook: ResolvePropertyValueHook): void {
+    this.resolvePropertyValueHook = hook;
+  }
+
+  resolvePropertyValue(mapping: unknown, contextData: any): unknown {
+    const defaultResolve = (path: string): unknown => {
+      const matches = JSONPath({ path, json: contextData, resultType: "value" });
+      return matches.length ? matches[0] : undefined;
+    };
+
+    if (this.resolvePropertyValueHook) {
+      return this.resolvePropertyValueHook(mapping, contextData, defaultResolve);
+    }
+
+    return typeof mapping === "string" ? defaultResolve(mapping) : undefined;
   }
 
   resolve(name: string): CraftNodeComponentMap<T> {

--- a/src/lib/craftNode.ts
+++ b/src/lib/craftNode.ts
@@ -24,7 +24,13 @@ export type CraftNodeRules = {
 
 export type CraftNode = {
   slots: Record<string, CraftNode[]>;
-  slotsPropsPropsMap?: Record<string, Record<string, string>>;
+  /**
+   * bucket -> { targetPropPath: mapping }. `mapping` is opaque to v-craft: a
+   * bare string is resolved as a JSONPath by default, anything else is only
+   * meaningful if the app's `CraftNodeResolver` registers
+   * `onResolvePropertyValue` to interpret it (see CraftNodeResolver.ts).
+   */
+  slotsPropsPropsMap?: Record<string, Record<string, unknown>>;
   componentName: string;
   parentUuid?: string | null;
   props: any;

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -127,7 +127,7 @@ export const useEditor = defineStore("editor", {
 
     updateNodeSlotsPropsPropsMap(
       nodeUuid: string,
-      slotsPropsPropsMap: Record<string, Record<string, string>>,
+      slotsPropsPropsMap: Record<string, Record<string, unknown>>,
     ) {
       const node = this.nodeMap.get(nodeUuid);
       if (node) {

--- a/tests/components/CraftEditorPanelNodeSlotPropsSettings.spec.ts
+++ b/tests/components/CraftEditorPanelNodeSlotPropsSettings.spec.ts
@@ -85,8 +85,8 @@ describe("CraftEditorPanelNodeSlotPropsSettings", () => {
     await wrapper.find("select").setValue("default");
 
     const inputs = wrapper.findAll("input");
-    await inputs[inputs.length - 2].setValue("label");
-    await inputs[inputs.length - 1].setValue("$.item.name");
+    await inputs[inputs.length - 1].setValue("label");
+    await wrapper.find("textarea").setValue("$.item.name");
     await waitForFormKitDebounce();
 
     const emitted = wrapper.emitted("update:slotsPropsPropsMap");
@@ -123,7 +123,7 @@ describe("CraftEditorPanelNodeSlotPropsSettings", () => {
     );
 
     await targetPropSelect.setValue("class");
-    await wrapper.find("input[placeholder='\$.item.name']").setValue("$.item.name");
+    await wrapper.find("textarea").setValue("$.item.name");
     await wrapper.find("select").setValue("default");
     await waitForFormKitDebounce();
 

--- a/tests/components/CraftNodeSlotPropsContext.spec.ts
+++ b/tests/components/CraftNodeSlotPropsContext.spec.ts
@@ -7,7 +7,9 @@ import CraftStaticRenderer from "../../src/components/CraftStaticRenderer.vue";
 import CraftNodeStatic from "../../src/components/CraftNodeStatic.vue";
 import CraftCanvas from "../../src/components/CraftCanvas.vue";
 import { CraftNode } from "../../src/lib/craftNode";
-import { CraftNodeResolverMap } from "../../src/lib/CraftNodeResolver";
+import CraftNodeResolver, {
+  CraftNodeResolverMap,
+} from "../../src/lib/CraftNodeResolver";
 
 const ScopedListComponent = defineComponent({
   name: "ScopedListComponent",
@@ -103,5 +105,40 @@ describe("slot props context mapping", () => {
     });
 
     expect(wrapper.find(".text-component").text()).toBe("Alice");
+  });
+
+  it("resolves a mapping through a registered onResolvePropertyValue hook", () => {
+    const textNode: CraftNode = {
+      uuid: uuidv4(),
+      componentName: "TextComponent",
+      props: {},
+      slots: {},
+      slotsPropsPropsMap: {
+        default: { label: { sources: ["$.item.name", "$.item.role"] } },
+      },
+    };
+
+    const listNode: CraftNode = {
+      uuid: uuidv4(),
+      componentName: "ScopedListComponent",
+      props: {},
+      slots: { default: [textNode] },
+    };
+
+    const resolver = new CraftNodeResolver(resolverMap);
+    resolver.onResolvePropertyValue((mapping, contextData, defaultResolve) => {
+      if (typeof mapping === "string") return defaultResolve(mapping);
+      const { sources } = mapping as { sources: string[] };
+      return sources.map((path) => defaultResolve(path)).join(" — ");
+    });
+
+    const wrapper = mount(CraftStaticRenderer, {
+      props: { nodes: [listNode], resolver },
+      global: {
+        components: { CraftStaticRenderer, CraftNodeStatic, CraftCanvas },
+      },
+    });
+
+    expect(wrapper.find(".text-component").text()).toBe("Alice — Admin");
   });
 });

--- a/tests/lib/CraftNodeResolver.spec.ts
+++ b/tests/lib/CraftNodeResolver.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import CraftNodeResolver from "../../src/lib/CraftNodeResolver";
+
+describe("CraftNodeResolver.resolvePropertyValue", () => {
+  it("resolves a bare string mapping as a JSONPath when no hook is registered", () => {
+    const resolver = new CraftNodeResolver();
+    expect(resolver.resolvePropertyValue("$.name", { name: "Alice" })).toBe(
+      "Alice",
+    );
+  });
+
+  it("returns undefined for a non-string mapping when no hook is registered", () => {
+    const resolver = new CraftNodeResolver();
+    expect(
+      resolver.resolvePropertyValue({ sources: ["$.name"] }, { name: "Alice" }),
+    ).toBeUndefined();
+  });
+
+  it("lets a registered hook interpret the mapping and wins over the default", () => {
+    const resolver = new CraftNodeResolver();
+    resolver.onResolvePropertyValue((mapping, contextData, defaultResolve) => {
+      if (typeof mapping === "string") return defaultResolve(mapping);
+      const { sources } = mapping as { sources: string[] };
+      return sources.map((path) => defaultResolve(path)).join(" ");
+    });
+
+    expect(
+      resolver.resolvePropertyValue(
+        { sources: ["$.first", "$.last"] },
+        { first: "Ada", last: "Lovelace" },
+      ),
+    ).toBe("Ada Lovelace");
+  });
+
+  it("still delegates plain string mappings to defaultResolve once a hook is registered", () => {
+    const resolver = new CraftNodeResolver();
+    resolver.onResolvePropertyValue((mapping, contextData, defaultResolve) =>
+      typeof mapping === "string" ? defaultResolve(mapping) : undefined,
+    );
+
+    expect(resolver.resolvePropertyValue("$.name", { name: "Alice" })).toBe(
+      "Alice",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`CraftNodeResolver` already lets a consumer override component resolution via `onResolveComponent`; `slotsPropsPropsMap` resolution had no equivalent extension point, so a mapping entry could only ever be a bare JSONPath string interpreted internally by `useResolveCraftNodeProps`.

Adds `onResolvePropertyValue(hook)`/`resolvePropertyValue` to `CraftNodeResolver`, mirroring `onResolveComponent`'s shape: the hook receives the raw mapping value, the resolved context data, and a `defaultResolve` callback that performs the existing bare-JSONPath lookup. `useResolveCraftNode` now threads its resolver into `useResolveCraftNodeProps`, which delegates through the resolver per mapping entry instead of JSONPath-resolving it directly (falling back to the previous bare-string-only behavior when no resolver is present) — this is a single choke point shared by `CraftNodeViewer`, `CraftNodeEditor`, and `CraftNodeStatic`, so editor, live viewer, and static/prerendered rendering are all covered uniformly.

`slotsPropsPropsMap`'s value type widens from `string` to `unknown`: v-craft never interprets the mapping beyond the default bare-path case, so a consumer is free to model richer mapping shapes (e.g. a formatter pipeline) without v-craft needing to know about them.

Also gives the editor's Props Mapping panel a JSON escape hatch: the JSONPath field is now a textarea that accepts either a bare path or a pasted JSON mapping object, so richer mappings are authorable by hand instead of requiring an external tool.

## Why

Consumed by `versa-stack/nuxt-pagekit`'s property-map formatter feature (`packages/renderer/lib/propertyMapping.ts`, registered via this hook in `vcraft-plugin.ts`) — without this, that plugin throws on every app boot since the method it calls doesn't exist yet.

## Testing

- `pnpm test`: 180/180 passing, including 3 new tests for `resolvePropertyValue` (bare-string default, hook override, hook still delegating to `defaultResolve`) and 1 new integration test exercising the hook through `CraftStaticRenderer`.
- Fixed 2 pre-existing tests in `CraftEditorPanelNodeSlotPropsSettings.spec.ts` that broke because the JSONPath field's element type changed from `input` to `textarea`.
- `pnpm run build`: clean, no new type errors.
- Verified live against `nuxt-pagekit`'s dev server (editor + viewer) — no boot crash, and the formatter pipeline produces correct output against real data (e.g. a live DEV.to feed's dates rendering via the `date` transform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)